### PR TITLE
fix: [MED-180] В алерте сохранения поменять кнопки местами

### DIFF
--- a/MedicinesV2/Supports/Extensions/UIAlerController+CustomController.swift
+++ b/MedicinesV2/Supports/Extensions/UIAlerController+CustomController.swift
@@ -58,10 +58,10 @@ extension UIAlertController {
             completion(newValue)
         }
         
-        let cancelAction = UIAlertAction(title: "Отмена", style: .destructive)
+        let cancelAction = UIAlertAction(title: "Отмена", style: .cancel)
         
-        addAction(saveAction)
         addAction(cancelAction)
+        addAction(saveAction)
         addTextField { textField in
             textField.autocapitalizationType = .sentences
             


### PR DESCRIPTION
Изменен стиль алерта при сохранении и редактировании в соответствии с HIG